### PR TITLE
Fix shared library compilation by turning on -fPIC for murmur

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(murmur3 STATIC ../murmur3/murmur3.c)
 target_include_directories(murmur3 INTERFACE ../murmur3)
+set_target_properties(murmur3 PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(api INTERFACE)
 target_include_directories(api INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>" "$<INSTALL_INTERFACE:include>")


### PR DESCRIPTION
Shady does not link correctly if the library is generated as a shared library, because murmur is not compiled with position independent code. This fixes the problem in a portable way.