### PR TITLE
vcc: Add a meta language for writing spir-v intrinsics

### DIFF
--- a/include/shady/grammar.json
+++ b/include/shady/grammar.json
@@ -137,6 +137,9 @@
     },
     {
       "name": "mem"
+    },
+    {
+      "name": "ext_op"
     }
   ],
   "nodes": [
@@ -743,10 +746,8 @@
       "description": "Unknown value-producing operation without side effects",
       "class": "value",
       "ops": [
-        { "name": "result_t", "class": "type" },
-        { "name": "set", "class": "string" },
-        { "name": "opcode", "type": "uint32_t" },
-        { "name": "operands", "class": "value", "list": true }
+        { "name": "op", "class": "ext_op" },
+        { "name": "arguments", "class": "value", "list": true }
       ]
     },
     {
@@ -755,10 +756,8 @@
       "class": ["mem", "value", "instruction"],
       "ops": [
         { "name": "mem", "class": "mem", "nullable": true },
-        { "name": "result_t", "class": "type", "nullable": true },
-        { "name": "set", "class": "string" },
-        { "name": "opcode", "type": "uint32_t" },
-        { "name": "operands", "class": "value", "list": true }
+        { "name": "op", "class": "ext_op" },
+        { "name": "arguments", "class": "value", "list": true }
       ]
     },
     {
@@ -767,9 +766,8 @@
       "class": "terminator",
       "ops": [
         { "name": "mem", "class": "mem", "nullable": true },
-        { "name": "set", "class": "string" },
-        { "name": "opcode", "type": "uint32_t" },
-        { "name": "operands", "class": "value", "list": true }
+        { "name": "op", "class": "ext_op" },
+        { "name": "arguments", "class": "none", "list": true }
       ]
     },
     {
@@ -777,9 +775,20 @@
       "type": false,
       "class": "type",
       "ops": [
+        { "name": "op", "class": "ext_op" },
+        { "name": "arguments", "class": "none", "list": true }
+      ]
+    },
+    {
+      "name": "ExtSpvOp",
+      "type": false,
+      "class": "ext_op",
+      "ops": [
         { "name": "set", "class": "string" },
         { "name": "opcode", "type": "uint32_t" },
-        { "name": "operands", "class": "none", "list": true }
+        { "name": "has_result", "type": "bool" },
+        { "name": "result_t", "class": "type", "nullable": true },
+        { "name": "ops_pattern", "class": "value", "list": true, "nullable": true }
       ]
     }
   ]

--- a/include/shady/grammar.json
+++ b/include/shady/grammar.json
@@ -788,7 +788,7 @@
         { "name": "opcode", "type": "uint32_t" },
         { "name": "has_result", "type": "bool" },
         { "name": "result_t", "class": "type", "nullable": true },
-        { "name": "ops_pattern", "class": "value", "list": true, "nullable": true }
+        { "name": "ops_pattern", "class": "none", "list": true, "nullable": true }
       ]
     }
   ]

--- a/include/shady/ir/ext.h
+++ b/include/shady/ir/ext.h
@@ -4,6 +4,8 @@
 #include "shady/ir/base.h"
 #include "shady/ir/builder.h"
 
+const Node* shd_make_ext_spv_op(IrArena* a, String set, int opcode, bool has_result, const Type* result_t, size_t argc);
+
 const Node* shd_bld_ext_instruction(BodyBuilder* bb, String set, int opcode, const Type* return_t, Nodes operands);
 
 #endif

--- a/src/backend/spirv/emit_spv.h
+++ b/src/backend/spirv/emit_spv.h
@@ -70,4 +70,6 @@ void shd_spv_register_interface(Emitter* emitter, const Node* n, SpvId id);
 
 void shd_spv_emit_debuginfo(Emitter*, const Node* n, SpvId id);
 
+size_t shd_emit_ops_with_pattern(Emitter*, ExtSpvOp op, Nodes arguments, uint32_t** out_ops);
+
 #endif

--- a/src/backend/spirv/emit_spv_type.c
+++ b/src/backend/spirv/emit_spv_type.c
@@ -241,11 +241,13 @@ SpvId spv_emit_type(Emitter* emitter, const Type* type) {
         case Type_JoinPointType_TAG: shd_error("These must be lowered beforehand")
         case Type_ExtType_TAG: {
             ExtType payload = type->payload.ext_type;
-            if (strcmp(payload.set, "spirv.core") == 0) {
-                LARRAY(SpvId, operands, payload.operands.count);
-                for (size_t i = 0; i < payload.operands.count; i++)
-                    operands[i] = spv_emit_type(emitter, payload.operands.nodes[i]);
-                new = spvb_type(emitter->file_builder, payload.opcode, payload.operands.count, operands);
+            ExtSpvOp op = payload.op->payload.ext_spv_op;
+            assert(op.has_result && !op.result_t);
+            if (strcmp(op.set, "spirv.core") == 0) {
+                LARRAY(SpvId, operands, payload.arguments.count);
+                for (size_t i = 0; i < payload.arguments.count; i++)
+                    operands[i] = spv_emit_type(emitter, payload.arguments.nodes[i]);
+                new = spvb_type(emitter->file_builder, op.opcode, payload.arguments.count, operands);
                 break;
             }
             shd_error("TODO: extended types")

--- a/src/backend/spirv/spirv_builder.c
+++ b/src/backend/spirv/spirv_builder.c
@@ -441,7 +441,7 @@ SpvId spvb_type(SpvbFileBuilder* file_builder, SpvOp op, size_t operands_count, 
     SpvId id = spvb_fresh_id(file_builder);
     ref_id(id);
     for (size_t i = 0; i < operands_count; i++)
-        ref_id(operands[i]);
+        literal_int(operands[i]);
     return id;
 }
 

--- a/src/backend/spirv/spirv_callable_shaders.c
+++ b/src/backend/spirv/spirv_callable_shaders.c
@@ -3,6 +3,7 @@
 #include "shady/ir/decl.h"
 #include "shady/ir/annotation.h"
 #include "shady/ir/function.h"
+#include "shady/ir/ext.h"
 #include "shady/analysis/uses.h"
 #include "shady/dict.h"
 
@@ -102,7 +103,8 @@ static Nodes rewrite_call(Context* ctx, BodyBuilder* bb, const Node* ocallee, co
         shd_bld_store(bb, ptr_composite_element_helper(a, var, shd_uint32_literal(a, i)), arg);
     }
 
-    shd_bld_add_instruction(bb, ext_instr_helper(a, shd_bld_mem(bb), NULL, "spirv.core", SpvOpExecuteCallableKHR, mk_nodes(a, shd_rewrite_node(r, ocallee), var)));
+    const Node* execute_callable_op = shd_make_ext_spv_op(a, "spirv.core", SpvOpExecuteCallableKHR, false, NULL, 2);
+    shd_bld_add_instruction(bb, ext_instr_helper(a, shd_bld_mem(bb), execute_callable_op, mk_nodes(a, shd_rewrite_node(r, ocallee), var)));
 
     size_t num_results = ofnt->payload.fn_type.return_types.count;
     LARRAY(const Node*, results, num_results);

--- a/src/frontend/llvm/CMakeLists.txt
+++ b/src/frontend/llvm/CMakeLists.txt
@@ -7,10 +7,11 @@ endif ()
 if (LLVM_FOUND AND SHADY_ENABLE_LLVM_FRONTEND)
     add_generated_file_python(FILE_NAME l2s_generated.c GENERATOR src.frontend.llvm.generator_l2s)
 
-    shady_add_component(NAME frontend_llvm SOURCES l2s.c l2s_type.c l2s_value.c l2s_instr.c l2s_meta.c l2s_postprocess.c l2s_annotations.c l2s_promote_byval_params.c ${CMAKE_CURRENT_BINARY_DIR}/l2s_generated.c)
+    shady_add_component(NAME frontend_llvm SOURCES l2s.c l2s_type.c l2s_value.c l2s_instr.c shady_meta_intrinsics.c l2s_meta.c l2s_postprocess.c l2s_annotations.c l2s_promote_byval_params.c ${CMAKE_CURRENT_BINARY_DIR}/l2s_generated.c)
 
     target_include_directories(frontend_llvm PRIVATE ${LLVM_INCLUDE_DIRS})
     target_include_directories(frontend_llvm PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}) # for l2s_generated.c
+    target_include_directories(frontend_llvm PRIVATE ${PROJECT_SOURCE_DIR}/vcc/include) # for shady_meta.h
     separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
     add_definitions(${LLVM_DEFINITIONS_LIST})
     target_compile_definitions(frontend_llvm PRIVATE "LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR}")

--- a/src/frontend/llvm/l2s.c
+++ b/src/frontend/llvm/l2s.c
@@ -365,6 +365,7 @@ bool shd_parse_llvm(const CompilerConfig* config, const LLVMFrontendConfig* fron
         .annotations_arena = shd_new_arena(),
         .src = src,
         .dst = dirty,
+        .intrinsics = create_shd_intrinsics(src),
     };
 
     LLVMValueRef global_annotations = LLVMGetNamedGlobal(src, "llvm.global.annotations");
@@ -395,6 +396,9 @@ bool shd_parse_llvm(const CompilerConfig* config, const LLVMFrontendConfig* fron
     shd_verify_module(*pmod);
     shd_destroy_ir_arena(arena);
 
+    destroy_shd_intrinsics(p.intrinsics);
+
+    // TODO: move this stuff outside the parser!
     RUN_PASS(shd_pass_lower_generic_globals, NULL)
     RUN_PASS(l2s_promote_byval_params, NULL);
 

--- a/src/frontend/llvm/l2s_private.h
+++ b/src/frontend/llvm/l2s_private.h
@@ -1,6 +1,8 @@
 #ifndef SHADY_L2S_PRIVATE_H
 #define SHADY_L2S_PRIVATE_H
 
+#include "shady_meta_intrinsics.h"
+
 #include "shady/fe/llvm.h"
 
 #include "shady/config.h"
@@ -21,6 +23,7 @@ typedef struct {
     Arena* annotations_arena;
     LLVMModuleRef src;
     Module* dst;
+    ShdIntrinsics* intrinsics;
 } Parser;
 
 typedef struct {

--- a/src/frontend/llvm/shady_meta_intrinsics.c
+++ b/src/frontend/llvm/shady_meta_intrinsics.c
@@ -1,0 +1,204 @@
+#include "shady_meta_intrinsics.h"
+#include "l2s_private.h"
+
+#include "log.h"
+#include "util.h"
+#include "dict.h"
+
+#include <stdlib.h>
+#include <assert.h>
+
+struct ShdIntrinsics_ {
+    LLVMModuleRef module;
+    Arena* arena;
+    size_t ids_count;
+    shady_parsed_meta_instruction** id_definitions;
+    struct Dict* name_map;
+};
+
+static void scan_definition_for_id(ShdIntrinsics* intrinsics, String name, LLVMValueRef global) {
+    global = LLVMGetInitializer(global);
+    LLVMValueRef meta = LLVMGetAggregateElement(global, 0);
+    uint64_t meta_value = LLVMConstIntGetZExtValue(meta);
+    shady_meta_id defined_id = 0;
+    switch ((shady_meta_instruction) meta_value) {
+        case SHADY_META_INVALID: assert(false); break;
+        case SHADY_META_DEFINE_LITERAL_I32:
+        case SHADY_META_DEFINE_LITERAL_STRING:
+        case SHADY_META_DEFINE_BUILTIN_TYPE:
+        case SHADY_META_DEFINE_PARAM_REF:
+        case SHADY_META_DEFINE_EXT_OP:
+            defined_id = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 1));
+            break;
+        default:
+            return;
+    }
+    assert(defined_id >= SHADY_META_IDS_BEGIN_AT);
+    defined_id -= SHADY_META_IDS_BEGIN_AT;
+    if (defined_id >= intrinsics->ids_count)
+        intrinsics->ids_count = defined_id + 1;
+    shd_dict_insert(String, shady_meta_id, intrinsics->name_map, name, defined_id);
+    return;
+}
+
+static void parse_definition(ShdIntrinsics* intrinsics, LLVMValueRef global) {
+    global = LLVMGetInitializer(global);
+    LLVMValueRef meta = LLVMGetAggregateElement(global, 0);
+    uint64_t meta_value = LLVMConstIntGetZExtValue(meta);
+    uint64_t defined_id = UINT64_MAX;
+    switch ((shady_meta_instruction) meta_value) {
+        case SHADY_META_INVALID: assert(false); break;
+        case SHADY_META_DEFINE_LITERAL_I32: {
+            defined_id = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 1)) - SHADY_META_IDS_BEGIN_AT;
+            uint32_t literal = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 2));
+            shd_log_fmt(DEBUGV, "meta[%d] = literal_i32 %d\n", defined_id, literal);
+            shady_parsed_meta_instruction* parsed = shd_arena_alloc(intrinsics->arena, sizeof(shady_parsed_meta_instruction));
+            *parsed = (shady_parsed_meta_instruction) {
+                .meta = meta_value,
+                .literal_i32 = {
+                    .defined_id = defined_id,
+                    .literal = literal,
+                }
+            };
+            intrinsics->id_definitions[defined_id] = (shady_parsed_meta_instruction*) parsed;
+            return;
+        } case SHADY_META_DEFINE_LITERAL_STRING: {
+            defined_id = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 1)) - SHADY_META_IDS_BEGIN_AT;
+            size_t len;
+            const char* string = LLVMGetAsString(LLVMGetInitializer(LLVMGetAggregateElement(global, 2)), &len);
+            shd_log_fmt(DEBUGV, "meta[%d] = literal_string '%s'\n", defined_id, string);
+            shady_parsed_meta_instruction* parsed = shd_arena_alloc(intrinsics->arena, sizeof(shady_parsed_meta_instruction));
+            char* allocated = shd_arena_alloc(intrinsics->arena, len + 1);
+            memcpy(allocated, string, len + 1);
+            *parsed = (shady_parsed_meta_instruction) {
+                .meta = meta_value,
+                .literal_string = {
+                    .defined_id = defined_id,
+                    .literal = allocated,
+                }
+            };
+            intrinsics->id_definitions[defined_id] = (shady_parsed_meta_instruction*) parsed;
+            return;
+        }
+        case SHADY_META_DEFINE_BUILTIN_TYPE: {
+            defined_id = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 1)) - SHADY_META_IDS_BEGIN_AT;
+            LLVMTypeRef t = LLVMTypeOf(LLVMGetAggregateElement(global, 2));
+            shd_log_fmt(DEBUGV, "meta[%d] = type %zx\n", defined_id, t);
+            shady_parsed_meta_instruction* parsed = shd_arena_alloc(intrinsics->arena, sizeof(shady_parsed_meta_instruction));
+            *parsed = (shady_parsed_meta_instruction) {
+                .meta = meta_value,
+                .builtin_type = {
+                    .defined_id = defined_id,
+                    .type = t,
+                }
+            };
+            intrinsics->id_definitions[defined_id] = (shady_parsed_meta_instruction*) parsed;
+            return;
+        } case SHADY_META_DEFINE_PARAM_REF: {
+            defined_id = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 1)) - SHADY_META_IDS_BEGIN_AT;
+            uint32_t idx = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 2));
+            shd_log_fmt(DEBUGV, "meta[%d] = param_idx %d\n", defined_id, idx);
+            shady_parsed_meta_instruction* parsed = shd_arena_alloc(intrinsics->arena, sizeof(shady_parsed_meta_instruction));
+            *parsed = (shady_parsed_meta_instruction) {
+                .meta = meta_value,
+                .param_ref = {
+                    .defined_id = defined_id,
+                    .param_idx = idx,
+                }
+            };
+            intrinsics->id_definitions[defined_id] = (shady_parsed_meta_instruction*) parsed;
+            return;
+        } case SHADY_META_DEFINE_EXT_OP: {
+            defined_id = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 1)) - SHADY_META_IDS_BEGIN_AT;
+            uint32_t op = LLVMConstIntGetZExtValue(LLVMGetAggregateElement(global, 2));
+            LLVMValueRef ops = LLVMGetAggregateElement(global, 4);
+            shady_meta_id* operands = NULL;
+            size_t len;
+            size_t num_operands = 0;
+            if (ops) {
+                char* src = LLVMGetAsString(LLVMGetInitializer(ops), &len);
+                char* allocated = shd_arena_alloc(intrinsics->arena, len + 1);
+                memcpy(allocated, src, len);
+                operands = (shady_meta_id*) allocated;
+                num_operands = len / 4;
+            }
+            shd_log_fmt(DEBUGV, "meta[%d] = ext_op %d(", defined_id, op);
+            for (size_t i = 0; i < num_operands; i++) {
+                operands[i] -= SHADY_META_IDS_BEGIN_AT;
+                shd_log_fmt(DEBUGV, "%d", operands[i]);
+                if (i + 1 < num_operands)
+                    shd_log_fmt(DEBUGV, ", ");
+            }
+            shd_log_fmt(DEBUGV, ")\n", defined_id, op);
+            shady_parsed_meta_instruction* parsed = shd_arena_alloc(intrinsics->arena, sizeof(shady_parsed_meta_instruction));
+            *parsed = (shady_parsed_meta_instruction) {
+                .meta = meta_value,
+                .ext_op = {
+                    .defined_id = defined_id,
+                    .op_code = op,
+                    .num_operands = num_operands,
+                    .operands = operands,
+                }
+            };
+            intrinsics->id_definitions[defined_id] = (shady_parsed_meta_instruction*) parsed;
+            return;
+        }
+    }
+}
+
+KeyHash shd_hash_string(const char** string);
+bool shd_compare_string(const char** a, const char** b);
+
+ShdIntrinsics* create_shd_intrinsics(LLVMModuleRef mod) {
+    ShdIntrinsics* intrinsics = calloc(sizeof(ShdIntrinsics), 1);
+    *intrinsics = (ShdIntrinsics) {
+        .module = mod,
+        .arena = shd_new_arena(),
+    };
+
+    intrinsics->name_map = shd_new_dict(String, uint32_t, (HashFn) shd_hash_string, (CmpFn) shd_compare_string);
+
+    LLVMValueRef global = LLVMGetFirstGlobal(mod);
+    while (global) {
+        const char* name = LLVMGetValueName(global);
+        if (shd_string_starts_with(name, "__shady_meta_op_"))
+            scan_definition_for_id(intrinsics, name + strlen("__shady_meta_op_"), global);
+        if (global == LLVMGetLastGlobal(mod))
+            break;
+        global = LLVMGetNextGlobal(global);
+    }
+
+    shd_log_fmt(DEBUG, "Shady meta intrinsics parser: found %d meta ID definitions\n", intrinsics->ids_count);
+    intrinsics->id_definitions = calloc(sizeof(shady_parsed_meta_instruction*), intrinsics->ids_count);
+
+    global = LLVMGetFirstGlobal(mod);
+    while (global) {
+        const char* name = LLVMGetValueName(global);
+        if (shd_string_starts_with(name, "__shady_meta_op_"))
+            parse_definition(intrinsics, global);
+        if (global == LLVMGetLastGlobal(mod))
+            break;
+        global = LLVMGetNextGlobal(global);
+    }
+
+    return intrinsics;
+}
+
+const shady_parsed_meta_instruction* shd_meta_id_definition(const ShdIntrinsics* intrinsics, size_t id) {
+    assert(id < intrinsics->ids_count);
+    return intrinsics->id_definitions[id];
+}
+
+shady_meta_id shd_meta_id_from_name(const ShdIntrinsics* intrinsics, const char* str) {
+    shady_meta_id* found = shd_dict_find_value(String, uint32_t, intrinsics->name_map, str);
+    if (found)
+        return *found;
+    return -1;
+}
+
+void destroy_shd_intrinsics(ShdIntrinsics* intrinsics) {
+    shd_destroy_arena(intrinsics->arena);
+    shd_destroy_dict(intrinsics->name_map);
+    free(intrinsics->id_definitions);
+    free(intrinsics);
+}

--- a/src/frontend/llvm/shady_meta_intrinsics.h
+++ b/src/frontend/llvm/shady_meta_intrinsics.h
@@ -1,0 +1,32 @@
+#ifndef SHADY_META_INTRINSICS_H
+#define SHADY_META_INTRINSICS_H
+
+#include "llvm-c/Core.h"
+#include "shady_meta.h"
+
+typedef struct ShdIntrinsics_ ShdIntrinsics;
+
+ShdIntrinsics* create_shd_intrinsics(LLVMModuleRef mod);
+void destroy_shd_intrinsics(ShdIntrinsics*);
+
+typedef struct {
+    shady_meta_instruction meta;
+    shady_meta_id defined_id;
+    LLVMTypeRef type;
+} shady_meta_builtin_type;
+
+typedef struct {
+    shady_meta_instruction meta;
+    union {
+        shady_meta_literal_i32 literal_i32;
+        shady_meta_literal_string literal_string;
+        shady_meta_builtin_type builtin_type;
+        shady_meta_param_ref param_ref;
+        shady_meta_ext_op ext_op;
+    };
+} shady_parsed_meta_instruction;
+
+const shady_parsed_meta_instruction* shd_meta_id_definition(const ShdIntrinsics*, size_t id);
+shady_meta_id shd_meta_id_from_name(const ShdIntrinsics*, const char*);
+
+#endif

--- a/src/frontend/slim/infer.c
+++ b/src/frontend/slim/infer.c
@@ -557,7 +557,7 @@ static const Node* process(Context* src_ctx, const Node* node) {
         return infer_annotation(&ctx, node);
     } else if (is_basic_block(node)) {
         return infer_basic_block(&ctx, node);
-    } else if (is_mem(node)) {
+    } else if (is_mem(node) || is_ext_op(node)) {
         return shd_recreate_node(&ctx.rewriter, node);
     }
     assert(false);

--- a/src/shady/analysis/cfg_dump.c
+++ b/src/shady/analysis/cfg_dump.c
@@ -39,9 +39,9 @@ static const Nodes* find_scope_info(const Node* abs) {
     const Node* mem = get_terminator_mem(terminator);
     const Nodes* info = NULL;
     while (mem) {
-        if (mem->tag == ExtInstr_TAG && strcmp(mem->payload.ext_instr.set, "shady.scope") == 0) {
-            if (!info || info->count > mem->payload.ext_instr.operands.count)
-                info = &mem->payload.ext_instr.operands;
+        if (mem->tag == ExtInstr_TAG && strcmp(mem->payload.ext_instr.op->payload.ext_spv_op.set, "shady.scope") == 0) {
+            if (!info || info->count > mem->payload.ext_instr.arguments.count)
+                info = &mem->payload.ext_instr.arguments;
         }
         mem = shd_get_parent_mem(mem);
     }

--- a/src/shady/check.c
+++ b/src/shady/check.c
@@ -585,14 +585,18 @@ const Type* _shd_check_type_generic_ptr_cast(IrArena* a, GenericPtrCast generic_
 }
 
 const Type* _shd_check_type_ext_value(IrArena* arena, ExtValue payload) {
-    return payload.result_t ? payload.result_t : unit_type(arena);
+    ExtSpvOp op = payload.op->payload.ext_spv_op;
+    return op.result_t ? op.result_t : unit_type(arena);
 }
 
 const Type* _shd_check_type_ext_instr(IrArena* arena, ExtInstr payload) {
-    return payload.result_t ? payload.result_t : unit_type(arena);
+    ExtSpvOp op = payload.op->payload.ext_spv_op;
+    return op.result_t ? op.result_t : unit_type(arena);
 }
 
 const Type* _shd_check_type_ext_terminator(IrArena* arena, ExtTerminator payload) {
+    ExtSpvOp op = payload.op->payload.ext_spv_op;
+    assert(!op.has_result);
     return noret_type(arena);
 }
 

--- a/src/shady/ir/ext.c
+++ b/src/shady/ir/ext.c
@@ -1,12 +1,21 @@
 #include "shady/ir/ext.h"
 #include "shady/ir/grammar.h"
 
+const Node* shd_make_ext_spv_op(IrArena* a, String set, int opcode, bool has_result, const Type* result_t, size_t argc) {
+    Nodes pattern = shd_empty(a);
+    for (size_t i = 0; i < argc; i++) {
+        pattern = shd_nodes_append(a, pattern, NULL);
+    }
+    return ext_spv_op_helper(a, set, opcode, has_result, result_t, pattern);
+}
+
 const Node* shd_bld_ext_instruction(BodyBuilder* bb, String set, int opcode, const Type* return_t, Nodes operands) {
-    return shd_bld_add_instruction(bb, ext_instr(shd_get_bb_arena(bb), (ExtInstr) {
+    IrArena* a = shd_get_bb_arena(bb);
+    const Node* ext_op = shd_make_ext_spv_op(a, set, opcode, true, return_t, operands.count);
+
+    return shd_bld_add_instruction(bb, ext_instr(a, (ExtInstr) {
         .mem = shd_bld_mem(bb),
-        .set = set,
-        .opcode = opcode,
-        .result_t = return_t,
-        .operands = operands,
+        .op = ext_op,
+        .arguments = operands,
     }));
 }

--- a/src/shady/passes/fncalls/software_dispatcher.c
+++ b/src/shady/passes/fncalls/software_dispatcher.c
@@ -111,14 +111,16 @@ static const Node* process(Context* ctx, const Node* old) {
             return lower_fn_addr(ctx, old->payload.fn_addr.fn);
         case ExtInstr_TAG: {
             ExtInstr payload = old->payload.ext_instr;
-            if (strcmp(payload.set, "shady.internal") == 0 && payload.opcode == ShadyOpDispatcherEnterFn) {
+            ExtSpvOp opcode = payload.op->payload.ext_spv_op;
+            if (strcmp(opcode.set, "shady.internal") == 0 && opcode.opcode == ShadyOpDispatcherEnterFn) {
                 return call_helper(a, shd_rewrite_node(r, payload.mem), get_top_dispatcher_fn(ctx), shd_empty(a));
             }
             break;
         }
         case ExtTerminator_TAG: {
             ExtTerminator payload = old->payload.ext_terminator;
-            if (strcmp(payload.set, "shady.internal") == 0 && payload.opcode == ShadyOpDispatcherContinue) {
+            ExtSpvOp opcode = payload.op->payload.ext_spv_op;
+            if (strcmp(opcode.set, "shady.internal") == 0 && opcode.opcode == ShadyOpDispatcherContinue) {
                 return fn_ret_helper(a, shd_rewrite_node(r, payload.mem), shd_empty(a));
             }
             break;

--- a/src/shady/passes/group/lower_inclusive_scan.c
+++ b/src/shady/passes/group/lower_inclusive_scan.c
@@ -72,16 +72,17 @@ static const Node* process(Context* ctx, const Node* node) {
     switch (node->tag) {
         case ExtInstr_TAG: {
             ExtInstr payload = node->payload.ext_instr;
-            if (strcmp(payload.set, "spirv.core") == 0) {
+            ExtSpvOp op = payload.op->payload.ext_spv_op;
+            if (strcmp(op.set, "spirv.core") == 0) {
                 for (size_t i = 0; i < NumGroupOps; i++) {
-                    if (payload.opcode == group_operations[i].spv_op) {
-                        if (shd_get_int_value(payload.operands.nodes[1], false) == SpvGroupOperationInclusiveScan) {
+                    if (op.opcode == group_operations[i].spv_op) {
+                        if (shd_get_int_value(payload.arguments.nodes[1], false) == SpvGroupOperationInclusiveScan) {
                             //assert(group_operations[i].I);
                             IrArena* oa = node->arena;
-                            payload.operands = shd_change_node_at_index(oa, payload.operands, 1, shd_uint32_literal(a, SpvGroupOperationExclusiveScan));
+                            payload.arguments = shd_change_node_at_index(oa, payload.arguments, 1, shd_uint32_literal(a, SpvGroupOperationExclusiveScan));
                             const Node* new = shd_recreate_node(r, ext_instr(oa, payload));
                             // new = prim_op_helper(a, group_operations[i].scalar, shd_empty(a), mk_nodes(a, new, group_operations[i].I(a, new->type) ));
-                            new = prim_op_helper(a, group_operations[i].scalar, mk_nodes(a, new, shd_recreate_node(r, payload.operands.nodes[2]) ));
+                            new = prim_op_helper(a, group_operations[i].scalar, mk_nodes(a, new, shd_recreate_node(r, payload.arguments.nodes[2]) ));
                             new = mem_and_value_helper(a, shd_rewrite_node(r, payload.mem), new);
                             return new;
                         }

--- a/src/shady/passes/group/lower_subgroup_ops.c
+++ b/src/shady/passes/group/lower_subgroup_ops.c
@@ -188,15 +188,16 @@ static const Node* process(Context* ctx, const Node* node) {
     switch (node->tag) {
         case ExtInstr_TAG: {
             ExtInstr payload = node->payload.ext_instr;
-            if (strcmp(payload.set, "spirv.core") == 0 && payload.opcode == SpvOpGroupNonUniformBroadcastFirst) {
+            ExtSpvOp opcode = payload.op->payload.ext_spv_op;
+            if (strcmp(opcode.set, "spirv.core") == 0 && opcode.opcode == SpvOpGroupNonUniformBroadcastFirst) {
                 BodyBuilder* bb = shd_bld_begin(a, shd_rewrite_node(r, payload.mem));
                 SubgroupOp op = {
-                    .iset = payload.set,
-                    .opcode = payload.opcode,
-                    .params = shd_singleton(shd_rewrite_node(r, payload.operands.nodes[0])),
+                    .iset = opcode.set,
+                    .opcode = opcode.opcode,
+                    .params = shd_singleton(shd_rewrite_node(r, payload.arguments.nodes[0])),
                 };
                 return shd_bld_to_instr_yield_values(bb, shd_singleton(
-                    rebuild_op(ctx, bb, op, shd_rewrite_node(r, payload.operands.nodes[1]), false)));
+                    rebuild_op(ctx, bb, op, shd_rewrite_node(r, payload.arguments.nodes[1]), false)));
             }
             break;
         }

--- a/src/shady/passes/structure/scope2control.c
+++ b/src/shady/passes/structure/scope2control.c
@@ -152,9 +152,11 @@ static const Nodes* find_scope_info(const Node* abs) {
     const Node* mem = get_terminator_mem(terminator);
     Nodes* info = NULL;
     while (mem) {
-        if (mem->tag == ExtInstr_TAG && strcmp(mem->payload.ext_instr.set, "shady.scope") == 0) {
-            if (!info || info->count > mem->payload.ext_instr.operands.count)
-                info = &mem->payload.ext_instr.operands;
+        if (mem->tag == ExtInstr_TAG) {
+            ExtSpvOp op = mem->payload.ext_instr.op->payload.ext_spv_op;
+            if (strcmp(op.set, "shady.scope") == 0)
+                if (!info || info->count > mem->payload.ext_instr.arguments.count)
+                    info = &mem->payload.ext_instr.arguments;
         }
         mem = shd_get_parent_mem(mem);
     }
@@ -283,7 +285,8 @@ static const Node* process_node(Context* ctx, const Node* node) {
         }
         // Eliminate now-useless scope instructions
         case ExtInstr_TAG: {
-            if (strcmp(node->payload.ext_instr.set, "shady.scope") == 0) {
+            ExtSpvOp op = node->payload.ext_instr.op->payload.ext_spv_op;
+            if (strcmp(op.set, "shady.scope") == 0) {
                 return shd_rewrite_node(r, node->payload.ext_instr.mem);
             }
             break;

--- a/test/vcc/cpp/textured.frag.cpp
+++ b/test/vcc/cpp/textured.frag.cpp
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <shady.h>
+#include <shady_sample.h>
 
 using namespace vcc;
 

--- a/test/vcc/meta/meta_test.c
+++ b/test/vcc/meta/meta_test.c
@@ -22,6 +22,6 @@ typedef float native_vec2     __attribute__((ext_vector_type(2)));
 __shady_declare_ext_inst(spv_texture2D, 87, __shady_ref(spv_param0), __shady_ref(spv_param1))
 native_vec4 texture2D(const sampler2D, native_vec2) __shady_bind_ext_inst(spv_texture2D)
 
-ray_generation_shader native_vec4 f(native_vec2 st) {
-    return texture2D(texSampler, st);
+fragment_shader void f(native_vec2 st) {
+    texture2D(texSampler, st);
 }

--- a/test/vcc/meta/meta_test.c
+++ b/test/vcc/meta/meta_test.c
@@ -1,0 +1,27 @@
+#include "shady.h"
+#include "shady_meta.h"
+
+__shady_declare_builtin_type(spv_float, float)
+__shady_declare_literal_i32(spv_0, 0)
+__shady_declare_literal_i32(spv_1, 1)
+
+__shady_declare_literal_string(spv_hi, "hi")
+
+__shady_declare_param_ref(spv_param0, 0)
+__shady_declare_param_ref(spv_param1, 1)
+
+__shady_declare_ext_type(sampledImage2D, 25, /* sampled type */ __shady_ref(spv_float), /* dim = 2D */ __shady_ref(spv_1), /* depth */ __shady_ref(spv_0), /* arrayed */ __shady_ref(spv_0), /* multisample */ __shady_ref(spv_0), /* sampled = 1 */ __shady_ref(spv_1), /* image format = unknown */ __shady_ref(spv_0))
+__shady_declare_ext_type(sampler2D, 27, __shady_ref(sampledImage2D))
+sampler2D texSampler;
+
+// declare the thing
+typedef float native_vec4     __attribute__((ext_vector_type(4)));
+typedef float native_vec3     __attribute__((ext_vector_type(3)));
+typedef float native_vec2     __attribute__((ext_vector_type(2)));
+
+__shady_declare_ext_inst(spv_texture2D, 87, __shady_ref(spv_param0), __shady_ref(spv_param1))
+native_vec4 texture2D(const sampler2D, native_vec2) __shady_bind_ext_inst(spv_texture2D)
+
+ray_generation_shader native_vec4 f(native_vec2 st) {
+    return texture2D(texSampler, st);
+}

--- a/test/vcc/textured.frag.c
+++ b/test/vcc/textured.frag.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 #include <shady.h>
+#include <shady_sample.h>
 
 descriptor_set(0) descriptor_binding(1) uniform_constant sampler2D texSampler;
 

--- a/vcc/include/shady.h
+++ b/vcc/include/shady.h
@@ -43,21 +43,21 @@ typedef unsigned native_uvec4 __attribute__((ext_vector_type(4)));
 typedef unsigned native_uvec3 __attribute__((ext_vector_type(3)));
 typedef unsigned native_uvec2 __attribute__((ext_vector_type(2)));
 
-typedef __attribute__((address_space(0x1000))) struct __shady_builtin_sampler1D* sampler1D;
+/*typedef __attribute__((address_space(0x1000))) struct __shady_builtin_sampler1D* sampler1D;
 typedef __attribute__((address_space(0x1001))) struct __shady_builtin_sampler2D* sampler2D;
 typedef __attribute__((address_space(0x1002))) struct __shady_builtin_sampler3D* sampler3D;
-typedef __attribute__((address_space(0x1003))) struct __shady_builtin_sampler3D* samplerCube;
+typedef __attribute__((address_space(0x1003))) struct __shady_builtin_sampler3D* samplerCube;*/
 
-native_vec4 texture1D(const sampler1D, float)           __asm__("shady::impure_op::spirv.core::87::Invocation");
+/*native_vec4 texture1D(const sampler1D, float)           __asm__("shady::impure_op::spirv.core::87::Invocation");
 native_vec4 texture2D(const sampler2D, native_vec2)     __asm__("shady::impure_op::spirv.core::87::Invocation");
 native_vec4 texture3D(const sampler3D, native_vec3)     __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 textureCube(const samplerCube, native_vec3) __asm__("shady::impure_op::spirv.core::87::Invocation");
+native_vec4 textureCube(const samplerCube, native_vec3) __asm__("shady::impure_op::spirv.core::87::Invocation");*/
 
 #if defined(__cplusplus)
-native_vec4 texture(const sampler1D, float)         __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 texture(const sampler2D, native_vec2)   __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 texture(const sampler3D, native_vec3)   __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 texture(const samplerCube, native_vec3) __asm__("shady::impure_op::spirv.core::87::Invocation");
+static inline native_vec4 texture(const sampler1D img, float coords) { return texture1D(img, coords); }
+static inline native_vec4 texture(const sampler2D img, native_vec2 coords) { return texture2D(img, coords); }
+static inline native_vec4 texture(const sampler3D img, native_vec3 coords) { return texture3D(img, coords); }
+static inline native_vec4 texture(const samplerCube img, native_vec3 coords) { return textureCube(img, coords); }
 #endif
 
 // builtins

--- a/vcc/include/shady.h
+++ b/vcc/include/shady.h
@@ -43,23 +43,6 @@ typedef unsigned native_uvec4 __attribute__((ext_vector_type(4)));
 typedef unsigned native_uvec3 __attribute__((ext_vector_type(3)));
 typedef unsigned native_uvec2 __attribute__((ext_vector_type(2)));
 
-/*typedef __attribute__((address_space(0x1000))) struct __shady_builtin_sampler1D* sampler1D;
-typedef __attribute__((address_space(0x1001))) struct __shady_builtin_sampler2D* sampler2D;
-typedef __attribute__((address_space(0x1002))) struct __shady_builtin_sampler3D* sampler3D;
-typedef __attribute__((address_space(0x1003))) struct __shady_builtin_sampler3D* samplerCube;*/
-
-/*native_vec4 texture1D(const sampler1D, float)           __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 texture2D(const sampler2D, native_vec2)     __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 texture3D(const sampler3D, native_vec3)     __asm__("shady::impure_op::spirv.core::87::Invocation");
-native_vec4 textureCube(const samplerCube, native_vec3) __asm__("shady::impure_op::spirv.core::87::Invocation");*/
-
-#if defined(__cplusplus)
-static inline native_vec4 texture(const sampler1D img, float coords) { return texture1D(img, coords); }
-static inline native_vec4 texture(const sampler2D img, native_vec2 coords) { return texture2D(img, coords); }
-static inline native_vec4 texture(const sampler3D img, native_vec3 coords) { return texture3D(img, coords); }
-static inline native_vec4 texture(const samplerCube img, native_vec3 coords) { return textureCube(img, coords); }
-#endif
-
 // builtins
 __attribute__((annotate("shady::builtin::FragCoord")))
 __attribute__((annotate("shady::io::389")))

--- a/vcc/include/shady_meta.h
+++ b/vcc/include/shady_meta.h
@@ -1,0 +1,89 @@
+#ifndef _SHADY_META_H
+#define _SHADY_META_H
+
+#include <stdint.h>
+
+#define SHADY_META_IDS_BEGIN_AT 0x1000
+
+typedef enum {
+    SHADY_META_INVALID,
+    SHADY_META_DEFINE_LITERAL_I32,
+    SHADY_META_DEFINE_LITERAL_STRING,
+    SHADY_META_DEFINE_BUILTIN_TYPE,
+    SHADY_META_DEFINE_PARAM_REF,
+    SHADY_META_DEFINE_EXT_OP,
+} shady_meta_instruction;
+
+typedef uint32_t shady_meta_id;
+
+typedef struct {
+    shady_meta_instruction meta;
+    shady_meta_id defined_id;
+    uint32_t literal;
+} shady_meta_literal_i32;
+
+#define __shady_define_literal_i32(id, name, value) \
+shady_meta_literal_i32 __shady_meta_op_##name = { SHADY_META_DEFINE_LITERAL_I32, id, value }; \
+static const uint32_t __shady_result_id_##name = id;
+
+typedef struct {
+    shady_meta_instruction meta;
+    shady_meta_id defined_id;
+    const char* literal;
+} shady_meta_literal_string;
+
+#define __shady_define_literal_string(id, name, value) \
+shady_meta_literal_string __shady_meta_op_##name = { SHADY_META_DEFINE_LITERAL_STRING, id, value }; \
+static const uint32_t __shady_result_id_##name = id;
+
+#define __shady_define_builtin_type(id, name, T) \
+typedef struct { \
+    shady_meta_instruction meta; \
+    shady_meta_id defined_id; \
+    T dummy; \
+} shady_meta_builtin_type_##name; \
+shady_meta_builtin_type_##name __shady_meta_op_##name = { SHADY_META_DEFINE_BUILTIN_TYPE, id }; \
+static const uint32_t __shady_result_id_##name = id;
+
+typedef struct {
+    shady_meta_instruction meta;
+    shady_meta_id defined_id;
+    unsigned param_idx;
+} shady_meta_param_ref;
+
+#define __shady_define_param_ref(id, name, idx) \
+shady_meta_param_ref __shady_meta_op_##name = { SHADY_META_DEFINE_PARAM_REF, id, idx }; \
+static const uint32_t __shady_result_id_##name = id;
+
+typedef struct {
+    shady_meta_instruction meta;
+    shady_meta_id defined_id;
+    uint32_t op_code;
+    /* only used in the parser */
+    uint32_t num_operands;
+    shady_meta_id* operands;
+} shady_meta_ext_op;
+
+#define __shady_define_ext_op(id, name, op, ...) \
+shady_meta_ext_op __shady_meta_op_##name = { SHADY_META_DEFINE_EXT_OP, id, op, 0, (uint32_t[]) { __VA_ARGS__ } }; \
+static const uint32_t __shady_result_id_##name = id;
+
+#define __shady_define_ext_type(id, name, op, ...) \
+typedef __attribute__((address_space(id))) struct __shady_id_as_addrspace_##name* name; \
+__shady_define_ext_op(id, name, op, __VA_ARGS__)
+
+#define __shady_define_ext_inst(id, name, op, ...) \
+__shady_define_ext_op(id, name, op, __VA_ARGS__)
+
+#define __shady_declare_literal_i32(name, value)    __shady_define_literal_i32(SHADY_META_IDS_BEGIN_AT + __COUNTER__, name, value)
+#define __shady_declare_literal_string(name, value) __shady_define_literal_string(SHADY_META_IDS_BEGIN_AT + __COUNTER__, name, value)
+#define __shady_declare_builtin_type(name, T)       __shady_define_builtin_type(SHADY_META_IDS_BEGIN_AT + __COUNTER__, name, T)
+#define __shady_declare_param_ref(name, i)          __shady_define_param_ref(SHADY_META_IDS_BEGIN_AT + __COUNTER__, name, i)
+#define __shady_declare_ext_type(name, op, ...)     __shady_define_ext_type(SHADY_META_IDS_BEGIN_AT + __COUNTER__, name, op, __VA_ARGS__)
+#define __shady_declare_ext_inst(name, op, ...)     __shady_define_ext_inst(SHADY_META_IDS_BEGIN_AT + __COUNTER__, name, op, __VA_ARGS__)
+
+// you cannot refer to a shady def directly, you must reference it using this macro
+#define __shady_ref(name) __shady_result_id_##name
+#define __shady_bind_ext_inst(name) __asm__("shady::meta_ext_inst::"#name);
+
+#endif

--- a/vcc/include/shady_sample.h
+++ b/vcc/include/shady_sample.h
@@ -1,0 +1,48 @@
+#ifndef SHADY_SAMPLE_H
+#define SHADY_SAMPLE_H
+
+#include "shady.h"
+#include "shady_meta.h"
+
+#if defined(__cplusplus) & !defined(SHADY_CPP_NO_NAMESPACE)
+namespace vcc {
+#endif
+
+__shady_declare_builtin_type(spv_float, float)
+__shady_declare_literal_i32(spv_0, 0)
+__shady_declare_literal_i32(spv_1, 1)
+__shady_declare_literal_i32(spv_2, 2)
+__shady_declare_literal_i32(spv_3, 3)
+
+__shady_declare_param_ref(spv_param0, 0)
+__shady_declare_param_ref(spv_param1, 1)
+
+__shady_declare_ext_type(sampledImage1D,   25, /* sampled type */ __shady_ref(spv_float), /* dim =   1D */ __shady_ref(spv_0), /* depth */ __shady_ref(spv_0), /* arrayed */ __shady_ref(spv_0), /* multisample */ __shady_ref(spv_0), /* sampled = 1 */ __shady_ref(spv_1), /* image format = unknown */ __shady_ref(spv_0))
+__shady_declare_ext_type(sampledImage2D,   25, /* sampled type */ __shady_ref(spv_float), /* dim =   2D */ __shady_ref(spv_1), /* depth */ __shady_ref(spv_0), /* arrayed */ __shady_ref(spv_0), /* multisample */ __shady_ref(spv_0), /* sampled = 1 */ __shady_ref(spv_1), /* image format = unknown */ __shady_ref(spv_0))
+__shady_declare_ext_type(sampledImage3D,   25, /* sampled type */ __shady_ref(spv_float), /* dim =   3D */ __shady_ref(spv_2), /* depth */ __shady_ref(spv_0), /* arrayed */ __shady_ref(spv_0), /* multisample */ __shady_ref(spv_0), /* sampled = 1 */ __shady_ref(spv_1), /* image format = unknown */ __shady_ref(spv_0))
+__shady_declare_ext_type(sampledImageCube, 25, /* sampled type */ __shady_ref(spv_float), /* dim = Cube */ __shady_ref(spv_3), /* depth */ __shady_ref(spv_0), /* arrayed */ __shady_ref(spv_0), /* multisample */ __shady_ref(spv_0), /* sampled = 1 */ __shady_ref(spv_1), /* image format = unknown */ __shady_ref(spv_0))
+
+__shady_declare_ext_type(sampler1D,   27, __shady_ref(sampledImage1D))
+__shady_declare_ext_type(sampler2D,   27, __shady_ref(sampledImage2D))
+__shady_declare_ext_type(sampler3D,   27, __shady_ref(sampledImage3D))
+__shady_declare_ext_type(samplerCube, 27, __shady_ref(sampledImageCube))
+
+__shady_declare_ext_inst(spv_texture_sample, 87, __shady_ref(spv_param0), __shady_ref(spv_param1))
+
+native_vec4   texture1D(const sampler1D,   float)       __shady_bind_ext_inst(spv_texture_sample)
+native_vec4   texture2D(const sampler2D,   native_vec2) __shady_bind_ext_inst(spv_texture_sample)
+native_vec4   texture3D(const sampler3D,   native_vec3) __shady_bind_ext_inst(spv_texture_sample)
+native_vec4 textureCube(const samplerCube, native_vec3) __shady_bind_ext_inst(spv_texture_sample)
+
+#if defined(__cplusplus)
+static inline native_vec4 texture(const sampler1D img, float coords) { return texture1D(img, coords); }
+static inline native_vec4 texture(const sampler2D img, native_vec2 coords) { return texture2D(img, coords); }
+static inline native_vec4 texture(const sampler3D img, native_vec3 coords) { return texture3D(img, coords); }
+static inline native_vec4 texture(const samplerCube img, native_vec3 coords) { return textureCube(img, coords); }
+#endif
+
+#if defined(__cplusplus) & !defined(SHADY_CPP_NO_NAMESPACE)
+}
+#endif
+
+#endif


### PR DESCRIPTION
We need a scalable solution to expose all the SPIR-V knobs in shady. This WIP branch implements spir-v intrinsics, similar to what you'd find in some modern shading languages. These SPIR-V intrinsics include a pattern to generate the SPIR-V code for them, mixing literals and ids.